### PR TITLE
AbstractKomaクラスの更新

### DIFF
--- a/Doubutsu/AbstractKoma.pde
+++ b/Doubutsu/AbstractKoma.pde
@@ -30,13 +30,30 @@ void draw() {
     rect(this.x*SQUARESIZE, this.y*SQUARESIZE, SQUARESIZE, SQUARESIZE);
   }
   
-  void move(int toX, int toY) {
-    this.updatePos(toX, toY);
+ void move(int toX, int toY) {
+    AbstractKoma koma = komaList.getKomaFromPlace(toX, toY);
+    if (koma==null) this.updatePos(toX, toY);
+    else if (koma.team != gs.turn) this.moveAndCapture(koma, toX, toY);
   }
+
   void updatePos(int toX, int toY) {
     this.x=toX;
     this.y=toY;
+    this.kStat.captured=false;
     gs.turn = (gs.turn+1)%2;
   }
+
+ void moveAndCapture(AbstractKoma enemy, int toX, int toY) {
+    this.updatePos(toX, toY);
+    if (enemy!=null) enemy.captured();
+  }
+
+  void captured() {
+    this.kStat.captured=true;
+    this.team = (this.team+1)%2;
+    this.y = board.mArea[this.team].getBlankYIndex();
+    this.x = board.mArea[this.team].posX;
+  }
+
 
 }


### PR DESCRIPTION
AbstractKomaの"move()","updatePos()"の更新および
 "moveAndCapture()","captured()" の追加を行いました。

駒が相手の駒と重なると駒が取得され左右の手持ち駒ゾーンに移動し、次のターンより
使用することが可能となります。